### PR TITLE
Avoid using animation to root element

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,9 @@
 <template>
+<div>
   <div class="animated fadeIn">
     Dashboard
   </div>
+</div>
 </template>
 
 <script>

--- a/pages/sample.vue
+++ b/pages/sample.vue
@@ -1,4 +1,5 @@
 <template>
+<div>
   <div class="animated fadeIn">
 
     <b-row>
@@ -27,7 +28,7 @@
       </b-col>
     </b-row>
   </div>
-
+</div>
 </template>
 
 <script>

--- a/pages/sample2.vue
+++ b/pages/sample2.vue
@@ -1,4 +1,5 @@
 <template>
+<div>
   <div class="animated fadeIn">
     <b-row>
       <b-col sm="6" md="4">
@@ -209,6 +210,7 @@
       </b-col>
     </b-row><!--/.row-->
   </div>
+</div>
 </template>
 
 <script>


### PR DESCRIPTION
pageコンポーネントのroot要素にアニメーションを適用すると、destroyed -> mounted の間に謎の待ち時間が発生したため、一旦root要素にアニメーションを使わないようにした。
(bootstrapのアニメーションが悪いのかと思ったが、uikitにしても同じ現象が起きた。)